### PR TITLE
feat: 카테고리 이미지 업로드 및 관리 로직 개선

### DIFF
--- a/src/main/java/com/haem/blogbackend/controller/CategoryController.java
+++ b/src/main/java/com/haem/blogbackend/controller/CategoryController.java
@@ -53,9 +53,12 @@ public CategoryController(CategoryService categoryService) {
     }
 
     @PatchMapping("/{id}/image")
-    public CategoryResponseDto updateCategoryImage(@PathVariable("id") Long id, @Valid @RequestBody CategoryUpdateImageRequestDto requestDto){
-        return categoryService.updateCategoryImage(id, requestDto);
+    public CategoryResponseDto updateCategoryImage(
+            @PathVariable Long id,
+            @RequestPart(value = "file", required = false) MultipartFile file) {
+        return categoryService.updateCategoryImage(id, file);
     }
+
 
     @GetMapping
     public List<CategoryResponseDto> getCategories(){

--- a/src/main/java/com/haem/blogbackend/controller/CategoryController.java
+++ b/src/main/java/com/haem/blogbackend/controller/CategoryController.java
@@ -14,7 +14,9 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
 import com.haem.blogbackend.dto.request.CategoryCreateRequestDto;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -32,8 +34,12 @@ public CategoryController(CategoryService categoryService) {
     }
 
     @PostMapping
-    public CategoryResponseDto createCategory(@Valid @RequestBody CategoryCreateRequestDto requestDto){
-        return categoryService.createCategory(requestDto);
+    public CategoryResponseDto createCategory(
+            @RequestPart("data") CategoryCreateRequestDto requestDto,
+            @RequestPart(value = "file", required = false)MultipartFile file)throws IOException {
+
+    CategoryResponseDto responseDto = categoryService.createCategory(requestDto,file);
+        return responseDto;
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/haem/blogbackend/dto/request/CategoryCreateRequestDto.java
+++ b/src/main/java/com/haem/blogbackend/dto/request/CategoryCreateRequestDto.java
@@ -17,7 +17,13 @@ public class CategoryCreateRequestDto {
     private String imageUrl;
     private String originalName;
 
-    public CategoryCreateRequestDto() {}
+    protected CategoryCreateRequestDto() {}
+
+    private CategoryCreateRequestDto(String categoryName, String imageUrl, String originalName) {
+        this.categoryName = categoryName;
+        this.imageUrl = imageUrl;
+        this.originalName = originalName;
+    }
 
     public static CategoryCreateRequestDto from(Category category){
         return CategoryCreateRequestDto.builder()

--- a/src/main/java/com/haem/blogbackend/exception/FileStorageException.java
+++ b/src/main/java/com/haem/blogbackend/exception/FileStorageException.java
@@ -1,0 +1,11 @@
+package com.haem.blogbackend.exception;
+
+public class FileStorageException extends RuntimeException{
+    public FileStorageException(String message) {
+        super(message);
+    }
+
+    public FileStorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/haem/blogbackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/haem/blogbackend/exception/GlobalExceptionHandler.java
@@ -29,4 +29,11 @@ public class GlobalExceptionHandler {
         ErrorResponse error = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
     }
+
+    @ExceptionHandler(FileStorageException.class)
+    public ResponseEntity<ErrorResponse> handleFileStorage(FileStorageException ex) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+
 }

--- a/src/main/java/com/haem/blogbackend/service/CategoryService.java
+++ b/src/main/java/com/haem/blogbackend/service/CategoryService.java
@@ -2,6 +2,8 @@ package com.haem.blogbackend.service;
 
 import com.haem.blogbackend.dto.request.CategoryUpdateImageRequestDto;
 import com.haem.blogbackend.dto.request.CategoryUpdateNameRequestDto;
+import com.haem.blogbackend.exception.FileStorageException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,12 +12,23 @@ import com.haem.blogbackend.dto.request.CategoryCreateRequestDto;
 import com.haem.blogbackend.dto.response.CategoryResponseDto;
 import com.haem.blogbackend.exception.CategoryNotFoundException;
 import com.haem.blogbackend.repository.CategoryRepository;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 @Transactional(readOnly = true)
 @Service
 public class CategoryService {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
     private final CategoryRepository categoryRepository;
 
     public CategoryService(CategoryRepository categoryRepository) {
@@ -27,8 +40,30 @@ public class CategoryService {
     }
 
     @Transactional
-    public CategoryResponseDto createCategory(CategoryCreateRequestDto requestDto){
-        Category category = Category.create(requestDto.getCategoryName());
+    public CategoryResponseDto createCategory(CategoryCreateRequestDto requestDto, MultipartFile file) throws IOException {
+        String imageUrl = null;
+        String originalName = null;
+
+        if(file != null && !file.isEmpty()){
+            originalName = file.getOriginalFilename();
+
+            LocalDate now = LocalDate.now();
+            String datePath = String.format("category/%d/%02d/%02d", now.getYear(), now.getMonthValue(), now.getDayOfMonth());
+            Path savePath = Paths.get(uploadDir, datePath);
+            Files.createDirectories(savePath);
+
+            String saveName = UUID.randomUUID() + "_" + originalName;
+            Path filePath = savePath.resolve(saveName);
+
+            try{
+                file.transferTo(filePath.toFile());
+            } catch (IOException e){
+                throw new FileStorageException("파일 저장 중 오류가 발생했습니다.", e);
+            }
+            imageUrl = "/uploadFiles/" + datePath + "/" + saveName;
+        }
+
+        Category category = Category.create(requestDto.getCategoryName(), imageUrl, originalName);
         Category saved = categoryRepository.save(category);
         return CategoryResponseDto.from(saved);
     }
@@ -55,7 +90,7 @@ public class CategoryService {
     public CategoryResponseDto updateCategoryImage(Long id, CategoryUpdateImageRequestDto requestDto){
         Category category = categoryRepository.findById(id)
                 .orElseThrow(() -> new CategoryNotFoundException(id));
-        if(requestDto.getImageUrl() != null || requestDto.getOriginalName() != null){
+        if(requestDto.getImageUrl() != null && requestDto.getOriginalName() != null){
             category.updateImage(requestDto.getImageUrl(), requestDto.getOriginalName());
         }
         return CategoryResponseDto.from(category);


### PR DESCRIPTION
## 개요
카테고리 생성·수정·삭제 시 이미지 파일을 안정적으로 처리할 수 있도록  
파일 업로드, 교체, 삭제 및 폴더 정리 로직을 전면 개선했습니다.

## 주요 변경 사항
- 카테고리 생성 시 이미지 업로드 로직 추가  
  - `/uploadFiles/category/YYYY/MM/DD` 구조로 파일 저장  
  - `UUID` 기반 파일명으로 중복 방지
- 이미지 수정(`updateCategoryImage`) 로직 개선  
  - 기존 이미지 삭제 후 새 파일 업로드  
  - 파일 미첨부 시 기존 이미지 유지하도록 조건 추가
- 삭제(`deleteCategory`) 로직 개선  
  - 카테고리 삭제 시 이미지 파일 함께 삭제  
  - 비어 있는 날짜 폴더 자동 정리(`cleanUpEmptyDirectories` 메서드 추가)
- 예외 처리 강화  
  - `FileStorageException` 추가  
  - 파일 입출력 실패 시 전역 예외 핸들러(`GlobalExceptionHandler`)에서 처리
- 로깅 개선  
  - `@Slf4j` 적용, 폴더 정리 실패 시 경고 로그 남김

## 테스트 
- 로컬 및 라즈베리파이 환경에서 이미지 업로드·수정·삭제 정상 동작 확인  
- 폴더 자동 생성 및 정리 기능 검증 완료
