### PR TITLE
fix: 댓글 API 공개 접근 허용 설정 추가

### DIFF
--- a/src/main/java/com/haem/blogbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/haem/blogbackend/global/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/api/categories/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/images/**").permitAll()
-                    .requestMatchers(HttpMethod.GET, "/api/comments/**").permitAll()
+                    .requestMatchers("/api/comments/**").permitAll() // guest 댓글 CRUD 위함
                     .anyRequest().authenticated()
             )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## 개요
게스트 사용자가 댓글을 조회 및 작성/수정/삭제할 수 있도록 댓글 관련 Public API에 대해 Spring Security 접근 제한을 수정했습니다.

## 주요 변경사항
- 댓글 Public API(`/api/comments`)에 대해 인증 없이 접근 가능하도록 Security 설정 수정
- 게스트 댓글 기능 사용을 위한 API 접근 정책 반영