### PR TITLE
feat: 댓글 시스템 보안 강화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.jsoup:jsoup:1.18.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.flywaydb:flyway-core'
     implementation 'org.jsoup:jsoup:1.18.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.flywaydb:flyway-core'
     implementation 'org.jsoup:jsoup:1.18.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/haem/blogbackend/comment/api/CommentPublicController.java
+++ b/src/main/java/com/haem/blogbackend/comment/api/CommentPublicController.java
@@ -11,6 +11,8 @@ import com.haem.blogbackend.comment.application.dto.CommentPublicCreateCommand;
 import com.haem.blogbackend.comment.application.dto.CommentPublicUpdateCommand;
 import com.haem.blogbackend.comment.application.dto.CommentResult;
 import com.haem.blogbackend.comment.application.dto.CommentSummaryResult;
+import com.haem.blogbackend.global.util.ClientIpResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -30,9 +32,11 @@ import java.util.List;
 @RequestMapping("/api/comments")
 public class CommentPublicController {
     private final CommentPublicService commentPublicService;
+    private final ClientIpResolver clientIpResolver;
 
-    public CommentPublicController(CommentPublicService commentPublicService) {
+    public CommentPublicController(CommentPublicService commentPublicService, ClientIpResolver clientIpResolver) {
         this.commentPublicService = commentPublicService;
+        this.clientIpResolver = clientIpResolver;
     }
 
     @GetMapping
@@ -45,13 +49,17 @@ public class CommentPublicController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public CommentResponseDto createComment(@Valid @RequestBody PublicCommentCreateRequestDto request) {
+    public CommentResponseDto createComment(
+            @Valid @RequestBody PublicCommentCreateRequestDto request,
+            HttpServletRequest httpServletRequest
+    ) {
         CommentPublicCreateCommand command = new CommentPublicCreateCommand(
                 request.getPostId(),
                 request.getParentId(),
                 request.getNickname(),
                 request.getPassword(),
-                request.getContent()
+                request.getContent(),
+                clientIpResolver.resolve(httpServletRequest)
         );
         CommentResult result = commentPublicService.createComment(command);
         return CommentResponseDto.from(result);

--- a/src/main/java/com/haem/blogbackend/comment/application/CommentContentSanitizer.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/CommentContentSanitizer.java
@@ -1,0 +1,13 @@
+package com.haem.blogbackend.comment.application;
+
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommentContentSanitizer {
+
+    public String sanitize(String content) {
+        return Jsoup.clean(content, Safelist.none());
+    }
+}

--- a/src/main/java/com/haem/blogbackend/comment/application/CommentPublicService.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/CommentPublicService.java
@@ -61,11 +61,11 @@ public class CommentPublicService {
         Post post = getPostOrThrow(command.postId());
         Comment parent = resolveParent(command.parentId());
         validateParentBelongsToPost(parent, command.postId());
-        String encodedPassword = passwordEncoder.encode(command.password());
 
         commentRateLimitService.validate(command.ipAddress());
         commentValidator.validateProfanity(command.content());
         String sanitizedContent = commentContentSanitizer.sanitize(command.content());
+        String encodedPassword = passwordEncoder.encode(command.password());
 
         Comment saved = commentRepository.save(
                 Comment.createByGuest(post, parent, command.nickname(), encodedPassword, sanitizedContent, command.ipAddress())

--- a/src/main/java/com/haem/blogbackend/comment/application/CommentPublicService.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/CommentPublicService.java
@@ -28,17 +28,26 @@ public class CommentPublicService {
     private final PostRepository postRepository;
     private final EntityFinder entityFinder;
     private final PasswordEncoder passwordEncoder;
+    private final CommentContentSanitizer commentContentSanitizer;
+    private final CommentValidator commentValidator;
+    private final CommentRateLimitService commentRateLimitService;
 
     public CommentPublicService(
             CommentRepository commentRepository,
             PostRepository postRepository,
             EntityFinder entityFinder,
-            PasswordEncoder passwordEncoder
+            PasswordEncoder passwordEncoder,
+            CommentContentSanitizer commentContentSanitizer,
+            CommentValidator commentValidator,
+            CommentRateLimitService commentRateLimitService
     ) {
         this.commentRepository = commentRepository;
         this.postRepository = postRepository;
         this.entityFinder = entityFinder;
         this.passwordEncoder = passwordEncoder;
+        this.commentContentSanitizer = commentContentSanitizer;
+        this.commentValidator = commentValidator;
+        this.commentRateLimitService = commentRateLimitService;
     }
 
     public List<CommentSummaryResult> getCommentsByPostId(Long postId) {
@@ -54,8 +63,12 @@ public class CommentPublicService {
         validateParentBelongsToPost(parent, command.postId());
         String encodedPassword = passwordEncoder.encode(command.password());
 
+        commentRateLimitService.validate(command.ipAddress());
+        commentValidator.validateProfanity(command.content());
+        String sanitizedContent = commentContentSanitizer.sanitize(command.content());
+
         Comment saved = commentRepository.save(
-                Comment.createByGuest(post, parent, command.nickname(), encodedPassword, command.content())
+                Comment.createByGuest(post, parent, command.nickname(), encodedPassword, sanitizedContent, command.ipAddress())
         );
         return CommentResult.from(saved);
     }

--- a/src/main/java/com/haem/blogbackend/comment/application/CommentRateLimitService.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/CommentRateLimitService.java
@@ -1,0 +1,38 @@
+package com.haem.blogbackend.comment.application;
+
+import com.haem.blogbackend.comment.domain.CommentRateLimitExceededException;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class CommentRateLimitService {
+
+    private static final int MAX_REQUEST_COUNT = 3;
+    private static final long WINDOW_SECONDS = 60;
+
+    private final Map<String, Deque<LocalDateTime>> requestHistoryByIp = new ConcurrentHashMap<>();
+
+    public void validate(String ipAddress) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime threshold = now.minusSeconds(WINDOW_SECONDS);
+
+        Deque<LocalDateTime> requestTimes = requestHistoryByIp.computeIfAbsent(ipAddress, key -> new ArrayDeque<>());
+
+        synchronized (requestTimes) {
+            while (!requestTimes.isEmpty() && requestTimes.peekFirst().isBefore(threshold)) {
+                requestTimes.pollFirst();
+            }
+
+            if (requestTimes.size() >= MAX_REQUEST_COUNT) {
+                throw new CommentRateLimitExceededException();
+            }
+
+            requestTimes.addLast(now);
+        }
+    }
+}

--- a/src/main/java/com/haem/blogbackend/comment/application/CommentValidator.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/CommentValidator.java
@@ -1,0 +1,28 @@
+package com.haem.blogbackend.comment.application;
+
+import com.haem.blogbackend.comment.domain.CommentProfanityException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CommentValidator {
+
+    private static final List<String> BANNED_WORDS = List.of(
+            "욕설1",
+            "욕설2",
+            "욕설3"
+    );
+
+    public void validateProfanity(String content) {
+        String lowerCaseContent = content.toLowerCase();
+
+        boolean hasBannedWord = BANNED_WORDS.stream()
+                .map(String::toLowerCase)
+                .anyMatch(lowerCaseContent::contains);
+
+        if (hasBannedWord) {
+            throw new CommentProfanityException();
+        }
+    }
+}

--- a/src/main/java/com/haem/blogbackend/comment/application/dto/CommentPublicCreateCommand.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/dto/CommentPublicCreateCommand.java
@@ -7,5 +7,6 @@ public record CommentPublicCreateCommand(
         Long parentId,
         String nickname,
         String password,
-        String content
+        String content,
+        String ipAddress
 ) implements CommentCreateCommand {}

--- a/src/main/java/com/haem/blogbackend/comment/domain/Comment.java
+++ b/src/main/java/com/haem/blogbackend/comment/domain/Comment.java
@@ -36,6 +36,9 @@ public class Comment {
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
 
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
     @Column(name = "is_pinned", nullable = false)
     private boolean isPinned;
 
@@ -62,13 +65,14 @@ public class Comment {
     // 기본생성자
     protected Comment(){}
 
-    public Comment(Post post, Admin admin, Comment parent, String nickname, String password, String content, Boolean isPinned){
+    public Comment(Post post, Admin admin, Comment parent, String nickname, String password, String content, String ipAddress, Boolean isPinned){
         this.post = post;
         this.admin = admin;
         this.parent = parent;
         this.nickname = nickname;
         this.password = password;
         this.content = content;
+        this.ipAddress = ipAddress;
         this.isPinned = isPinned;
     }
 
@@ -100,6 +104,10 @@ public class Comment {
 
     public String getContent(){
         return content;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
     }
 
     public Boolean getIsPinned(){
@@ -139,13 +147,13 @@ public class Comment {
     }
 
     public static Comment createByAdmin(Post post, Admin admin, Comment parent, String content) {
-        Comment c = new Comment(post, admin, parent, null, null, content, false);
+        Comment c = new Comment(post, admin, parent, null, null, content, null, false);
         c.authorType = CommentAuthorType.ADMIN;
         return c;
     }
 
-    public static Comment createByGuest(Post post, Comment parent, String nickname, String password, String content) {
-        Comment c = new Comment(post, null, parent, nickname, password, content, false);
+    public static Comment createByGuest(Post post, Comment parent, String nickname, String password, String content, String ipAddress) {
+        Comment c = new Comment(post, null, parent, nickname, password, content, ipAddress, false);
         c.authorType = CommentAuthorType.GUEST;
         return c;
     }

--- a/src/main/java/com/haem/blogbackend/comment/domain/CommentProfanityException.java
+++ b/src/main/java/com/haem/blogbackend/comment/domain/CommentProfanityException.java
@@ -1,0 +1,9 @@
+package com.haem.blogbackend.comment.domain;
+
+import com.haem.blogbackend.global.error.exception.base.BadRequestException;
+
+public class CommentProfanityException extends BadRequestException {
+    public CommentProfanityException() {
+        super("댓글에 금칙어가 포함되어 있습니다.");
+    }
+}

--- a/src/main/java/com/haem/blogbackend/comment/domain/CommentRateLimitExceededException.java
+++ b/src/main/java/com/haem/blogbackend/comment/domain/CommentRateLimitExceededException.java
@@ -1,0 +1,9 @@
+package com.haem.blogbackend.comment.domain;
+
+import com.haem.blogbackend.global.error.exception.base.BadRequestException;
+
+public class CommentRateLimitExceededException extends BadRequestException {
+    public CommentRateLimitExceededException() {
+        super("동일 IP에서 1분에 최대 3개의 댓글만 작성할 수 있습니다.");
+    }
+}

--- a/src/main/java/com/haem/blogbackend/global/util/ClientIpResolver.java
+++ b/src/main/java/com/haem/blogbackend/global/util/ClientIpResolver.java
@@ -7,16 +7,6 @@ import org.springframework.stereotype.Component;
 public class ClientIpResolver {
 
     public String resolve(HttpServletRequest request) {
-        String xForwardedFor = request.getHeader("X-Forwarded-For");
-        if (xForwardedFor != null && !xForwardedFor.isBlank()) {
-            return xForwardedFor.split(",")[0].trim();
-        }
-
-        String xRealIp = request.getHeader("X-Real-IP");
-        if (xRealIp != null && !xRealIp.isBlank()) {
-            return xRealIp.trim();
-        }
-
         return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/haem/blogbackend/global/util/ClientIpResolver.java
+++ b/src/main/java/com/haem/blogbackend/global/util/ClientIpResolver.java
@@ -1,4 +1,22 @@
 package com.haem.blogbackend.global.util;
 
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+@Component
 public class ClientIpResolver {
+
+    public String resolve(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isBlank()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+
+        String xRealIp = request.getHeader("X-Real-IP");
+        if (xRealIp != null && !xRealIp.isBlank()) {
+            return xRealIp.trim();
+        }
+
+        return request.getRemoteAddr();
+    }
 }

--- a/src/main/resources/db/migration/V1__add_comment_ip_address_column.sql
+++ b/src/main/resources/db/migration/V1__add_comment_ip_address_column.sql
@@ -1,2 +1,0 @@
-ALTER TABLE comment
-    ADD COLUMN IF NOT EXISTS ip_address VARCHAR(45);

--- a/src/main/resources/db/migration/V1__add_comment_ip_address_column.sql
+++ b/src/main/resources/db/migration/V1__add_comment_ip_address_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE comment
+    ADD COLUMN IF NOT EXISTS ip_address VARCHAR(45);


### PR DESCRIPTION
## 개요
댓글 생성 과정의 보안 강화를 위해 XSS 방어(HTML sanitize), 금칙어 필터, IP 기반 rate limit, 작성자 IP 저장 및 검증 흐름 정리를 적용했습니다.

## 주요 변경사항
- `build.gradle`에 `jsoup` 의존성을 추가하고 `CommentContentSanitizer`를 도입하여 댓글 저장 전에 HTML을 sanitize하도록 적용했습니다.
- 금칙어 리스트 기반 `CommentValidator`와 `CommentProfanityException`을 추가하여 금칙어 포함 시 예외를 발생시키도록 했습니다.
- 동일 IP 기준 1분당 최대 3회 제한하는 `CommentRateLimitService`와 `CommentRateLimitExceededException`을 추가하고, 컨트롤러에서 `ClientIpResolver`를 통해 IP를 추출해 커맨드로 전달하도록 변경했습니다.
- `Comment` 엔티티에 `ipAddress` 필드를 추가하고 게스트 댓글 생성 시 IP를 저장하도록 생성자 및 팩토리 메서드를 변경했습니다.
- 댓글 생성 순서를 요청대로 `rate limit 검사 → 금칙어 검사 → content sanitize → DB 저장` 순으로 정리했습니다.
- 작업 브랜치: `feat/comment-security`에 변경을 적용했습니다.
- 자동화 테스트: 로컬에서 `./gradlew test`를 시도했으나 실행 권한 문제 및 네트워크(프록시)로 인해 Gradle 배포판 다운로드가 실패하여 테스트를 정상적으로 실행하지 못했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b20a0bbe3c8320a01118a7a027451a)