### PR TITLE
fix: 댓글 보안 검증 순서 및 IP 처리 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.jsoup:jsoup:1.18.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.jsoup:jsoup:1.18.3'
+    implementation 'org.flywaydb:flyway-core'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/haem/blogbackend/comment/api/CommentPublicController.java
+++ b/src/main/java/com/haem/blogbackend/comment/api/CommentPublicController.java
@@ -11,6 +11,8 @@ import com.haem.blogbackend.comment.application.dto.CommentPublicCreateCommand;
 import com.haem.blogbackend.comment.application.dto.CommentPublicUpdateCommand;
 import com.haem.blogbackend.comment.application.dto.CommentResult;
 import com.haem.blogbackend.comment.application.dto.CommentSummaryResult;
+import com.haem.blogbackend.global.util.ClientIpResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -30,9 +32,11 @@ import java.util.List;
 @RequestMapping("/api/comments")
 public class CommentPublicController {
     private final CommentPublicService commentPublicService;
+    private final ClientIpResolver clientIpResolver;
 
-    public CommentPublicController(CommentPublicService commentPublicService) {
+    public CommentPublicController(CommentPublicService commentPublicService, ClientIpResolver clientIpResolver) {
         this.commentPublicService = commentPublicService;
+        this.clientIpResolver = clientIpResolver;
     }
 
     @GetMapping
@@ -45,13 +49,17 @@ public class CommentPublicController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public CommentResponseDto createComment(@Valid @RequestBody PublicCommentCreateRequestDto request) {
+    public CommentResponseDto createComment(
+            @Valid @RequestBody PublicCommentCreateRequestDto request,
+            HttpServletRequest httpServletRequest
+    ) {
         CommentPublicCreateCommand command = new CommentPublicCreateCommand(
                 request.getPostId(),
                 request.getParentId(),
                 request.getNickname(),
                 request.getPassword(),
-                request.getContent()
+                request.getContent(),
+                clientIpResolver.resolve(httpServletRequest)
         );
         CommentResult result = commentPublicService.createComment(command);
         return CommentResponseDto.from(result);

--- a/src/main/java/com/haem/blogbackend/comment/application/CommentContentSanitizer.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/CommentContentSanitizer.java
@@ -1,0 +1,13 @@
+package com.haem.blogbackend.comment.application;
+
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommentContentSanitizer {
+
+    public String sanitize(String content) {
+        return Jsoup.clean(content, Safelist.none());
+    }
+}

--- a/src/main/java/com/haem/blogbackend/comment/application/CommentPublicService.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/CommentPublicService.java
@@ -61,10 +61,9 @@ public class CommentPublicService {
         Post post = getPostOrThrow(command.postId());
         Comment parent = resolveParent(command.parentId());
         validateParentBelongsToPost(parent, command.postId());
-        String encodedPassword = passwordEncoder.encode(command.password());
-
         commentRateLimitService.validate(command.ipAddress());
         commentValidator.validateProfanity(command.content());
+        String encodedPassword = passwordEncoder.encode(command.password());
         String sanitizedContent = commentContentSanitizer.sanitize(command.content());
 
         Comment saved = commentRepository.save(

--- a/src/main/java/com/haem/blogbackend/comment/application/CommentPublicService.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/CommentPublicService.java
@@ -28,17 +28,26 @@ public class CommentPublicService {
     private final PostRepository postRepository;
     private final EntityFinder entityFinder;
     private final PasswordEncoder passwordEncoder;
+    private final CommentContentSanitizer commentContentSanitizer;
+    private final CommentValidator commentValidator;
+    private final CommentRateLimitService commentRateLimitService;
 
     public CommentPublicService(
             CommentRepository commentRepository,
             PostRepository postRepository,
             EntityFinder entityFinder,
-            PasswordEncoder passwordEncoder
+            PasswordEncoder passwordEncoder,
+            CommentContentSanitizer commentContentSanitizer,
+            CommentValidator commentValidator,
+            CommentRateLimitService commentRateLimitService
     ) {
         this.commentRepository = commentRepository;
         this.postRepository = postRepository;
         this.entityFinder = entityFinder;
         this.passwordEncoder = passwordEncoder;
+        this.commentContentSanitizer = commentContentSanitizer;
+        this.commentValidator = commentValidator;
+        this.commentRateLimitService = commentRateLimitService;
     }
 
     public List<CommentSummaryResult> getCommentsByPostId(Long postId) {
@@ -54,8 +63,12 @@ public class CommentPublicService {
         validateParentBelongsToPost(parent, command.postId());
         String encodedPassword = passwordEncoder.encode(command.password());
 
+        commentRateLimitService.validate(command.ipAddress());
+        commentValidator.validateProfanity(command.content());
+        String sanitizedContent = commentContentSanitizer.sanitize(command.content());
+
         Comment saved = commentRepository.save(
-                Comment.createByGuest(post, parent, command.nickname(), encodedPassword, command.content())
+                Comment.createByGuest(post, parent, command.nickname(), encodedPassword, sanitizedContent, command.ipAddress())
         );
         return CommentResult.from(saved);
     }

--- a/src/main/java/com/haem/blogbackend/comment/application/CommentRateLimitService.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/CommentRateLimitService.java
@@ -1,0 +1,38 @@
+package com.haem.blogbackend.comment.application;
+
+import com.haem.blogbackend.comment.domain.CommentRateLimitExceededException;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class CommentRateLimitService {
+
+    private static final int MAX_REQUEST_COUNT = 3;
+    private static final long WINDOW_SECONDS = 60;
+
+    private final Map<String, Deque<LocalDateTime>> requestHistoryByIp = new ConcurrentHashMap<>();
+
+    public void validate(String ipAddress) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime threshold = now.minusSeconds(WINDOW_SECONDS);
+
+        Deque<LocalDateTime> requestTimes = requestHistoryByIp.computeIfAbsent(ipAddress, key -> new ArrayDeque<>());
+
+        synchronized (requestTimes) {
+            while (!requestTimes.isEmpty() && requestTimes.peekFirst().isBefore(threshold)) {
+                requestTimes.pollFirst();
+            }
+
+            if (requestTimes.size() >= MAX_REQUEST_COUNT) {
+                throw new CommentRateLimitExceededException();
+            }
+
+            requestTimes.addLast(now);
+        }
+    }
+}

--- a/src/main/java/com/haem/blogbackend/comment/application/CommentValidator.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/CommentValidator.java
@@ -1,0 +1,28 @@
+package com.haem.blogbackend.comment.application;
+
+import com.haem.blogbackend.comment.domain.CommentProfanityException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CommentValidator {
+
+    private static final List<String> BANNED_WORDS = List.of(
+            "욕설1",
+            "욕설2",
+            "욕설3"
+    );
+
+    public void validateProfanity(String content) {
+        String lowerCaseContent = content.toLowerCase();
+
+        boolean hasBannedWord = BANNED_WORDS.stream()
+                .map(String::toLowerCase)
+                .anyMatch(lowerCaseContent::contains);
+
+        if (hasBannedWord) {
+            throw new CommentProfanityException();
+        }
+    }
+}

--- a/src/main/java/com/haem/blogbackend/comment/application/dto/CommentPublicCreateCommand.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/dto/CommentPublicCreateCommand.java
@@ -7,5 +7,6 @@ public record CommentPublicCreateCommand(
         Long parentId,
         String nickname,
         String password,
-        String content
+        String content,
+        String ipAddress
 ) implements CommentCreateCommand {}

--- a/src/main/java/com/haem/blogbackend/comment/domain/Comment.java
+++ b/src/main/java/com/haem/blogbackend/comment/domain/Comment.java
@@ -36,6 +36,9 @@ public class Comment {
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
 
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
     @Column(name = "is_pinned", nullable = false)
     private boolean isPinned;
 
@@ -62,13 +65,14 @@ public class Comment {
     // 기본생성자
     protected Comment(){}
 
-    public Comment(Post post, Admin admin, Comment parent, String nickname, String password, String content, Boolean isPinned){
+    public Comment(Post post, Admin admin, Comment parent, String nickname, String password, String content, String ipAddress, Boolean isPinned){
         this.post = post;
         this.admin = admin;
         this.parent = parent;
         this.nickname = nickname;
         this.password = password;
         this.content = content;
+        this.ipAddress = ipAddress;
         this.isPinned = isPinned;
     }
 
@@ -100,6 +104,10 @@ public class Comment {
 
     public String getContent(){
         return content;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
     }
 
     public Boolean getIsPinned(){
@@ -139,13 +147,13 @@ public class Comment {
     }
 
     public static Comment createByAdmin(Post post, Admin admin, Comment parent, String content) {
-        Comment c = new Comment(post, admin, parent, null, null, content, false);
+        Comment c = new Comment(post, admin, parent, null, null, content, null, false);
         c.authorType = CommentAuthorType.ADMIN;
         return c;
     }
 
-    public static Comment createByGuest(Post post, Comment parent, String nickname, String password, String content) {
-        Comment c = new Comment(post, null, parent, nickname, password, content, false);
+    public static Comment createByGuest(Post post, Comment parent, String nickname, String password, String content, String ipAddress) {
+        Comment c = new Comment(post, null, parent, nickname, password, content, ipAddress, false);
         c.authorType = CommentAuthorType.GUEST;
         return c;
     }

--- a/src/main/java/com/haem/blogbackend/comment/domain/CommentProfanityException.java
+++ b/src/main/java/com/haem/blogbackend/comment/domain/CommentProfanityException.java
@@ -1,0 +1,9 @@
+package com.haem.blogbackend.comment.domain;
+
+import com.haem.blogbackend.global.error.exception.base.BadRequestException;
+
+public class CommentProfanityException extends BadRequestException {
+    public CommentProfanityException() {
+        super("댓글에 금칙어가 포함되어 있습니다.");
+    }
+}

--- a/src/main/java/com/haem/blogbackend/comment/domain/CommentRateLimitExceededException.java
+++ b/src/main/java/com/haem/blogbackend/comment/domain/CommentRateLimitExceededException.java
@@ -1,0 +1,9 @@
+package com.haem.blogbackend.comment.domain;
+
+import com.haem.blogbackend.global.error.exception.base.BadRequestException;
+
+public class CommentRateLimitExceededException extends BadRequestException {
+    public CommentRateLimitExceededException() {
+        super("동일 IP에서 1분에 최대 3개의 댓글만 작성할 수 있습니다.");
+    }
+}

--- a/src/main/java/com/haem/blogbackend/global/util/ClientIpResolver.java
+++ b/src/main/java/com/haem/blogbackend/global/util/ClientIpResolver.java
@@ -7,16 +7,6 @@ import org.springframework.stereotype.Component;
 public class ClientIpResolver {
 
     public String resolve(HttpServletRequest request) {
-        String xForwardedFor = request.getHeader("X-Forwarded-For");
-        if (xForwardedFor != null && !xForwardedFor.isBlank()) {
-            return xForwardedFor.split(",")[0].trim();
-        }
-
-        String xRealIp = request.getHeader("X-Real-IP");
-        if (xRealIp != null && !xRealIp.isBlank()) {
-            return xRealIp.trim();
-        }
-
         return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/haem/blogbackend/global/util/ClientIpResolver.java
+++ b/src/main/java/com/haem/blogbackend/global/util/ClientIpResolver.java
@@ -1,4 +1,22 @@
 package com.haem.blogbackend.global.util;
 
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+@Component
 public class ClientIpResolver {
+
+    public String resolve(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isBlank()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+
+        String xRealIp = request.getHeader("X-Real-IP");
+        if (xRealIp != null && !xRealIp.isBlank()) {
+            return xRealIp.trim();
+        }
+
+        return request.getRemoteAddr();
+    }
 }

--- a/src/main/resources/db/migration/V1__add_comment_ip_address.sql
+++ b/src/main/resources/db/migration/V1__add_comment_ip_address.sql
@@ -1,0 +1,2 @@
+ALTER TABLE comment
+ADD COLUMN IF NOT EXISTS ip_address VARCHAR(45);

--- a/src/test/java/com/haem/blogbackend/global/util/ClientIpResolverTest.java
+++ b/src/test/java/com/haem/blogbackend/global/util/ClientIpResolverTest.java
@@ -1,0 +1,23 @@
+package com.haem.blogbackend.global.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClientIpResolverTest {
+
+    private final ClientIpResolver clientIpResolver = new ClientIpResolver();
+
+    @Test
+    void spoofableHeadersDoNotOverrideRemoteAddr() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("10.0.0.1");
+        request.addHeader("X-Forwarded-For", "203.0.113.10");
+        request.addHeader("X-Real-IP", "198.51.100.20");
+
+        String resolvedIp = clientIpResolver.resolve(request);
+
+        assertThat(resolvedIp).isEqualTo("10.0.0.1");
+    }
+}


### PR DESCRIPTION
## 개요
PR 리뷰에서 지적된 댓글 보안 검증 순서, 클라이언트 IP 스푸핑 취약점 및 DB 마이그레이션 누락을 반영한 변경입니다.

## 주요 변경사항
- 댓글 생성 시 rate limit 및 욕설 검증을 비밀번호 해싱 이전에 수행하도록 순서를 변경했습니다 (`CommentPublicService#createComment`).
- `ClientIpResolver`가 `X-Forwarded-For` 및 `X-Real-IP` 헤더를 더 이상 사용하지 않고 `request.getRemoteAddr()`만 반환하도록 수정했습니다.
- Flyway 의존성을 `build.gradle`에 추가하고 `comment` 테이블에 `ip_address` 컬럼을 안전하게 추가하는 마이그레이션 파일 `V1__add_comment_ip_address.sql`을 추가했습니다.
- `ClientIpResolver`가 스푸핑 가능한 헤더에 의해 덮어쓰이지 않는지 검증하는 단위 테스트 `ClientIpResolverTest`를 추가했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b220beaeb4832092043341782df046)