### PR TITLE
refactor: guest 네이밍을 public으로 통일

### DIFF
--- a/src/main/java/com/haem/blogbackend/comment/application/CommentPublicService.java
+++ b/src/main/java/com/haem/blogbackend/comment/application/CommentPublicService.java
@@ -68,7 +68,7 @@ public class CommentPublicService {
         String encodedPassword = passwordEncoder.encode(command.password());
 
         Comment saved = commentRepository.save(
-                Comment.createByGuest(post, parent, command.nickname(), encodedPassword, sanitizedContent, command.ipAddress())
+                Comment.createByPublic(post, parent, command.nickname(), encodedPassword, sanitizedContent, command.ipAddress())
         );
         return CommentResult.from(saved);
     }

--- a/src/main/java/com/haem/blogbackend/comment/domain/Comment.java
+++ b/src/main/java/com/haem/blogbackend/comment/domain/Comment.java
@@ -58,7 +58,7 @@ public class Comment {
     @PrePersist
     private void prePersist() {
         if (authorType == null) {
-            authorType = (admin != null) ? CommentAuthorType.ADMIN : CommentAuthorType.GUEST;
+            authorType = (admin != null) ? CommentAuthorType.ADMIN : CommentAuthorType.PUBLIC;
         }
     }
 
@@ -152,9 +152,9 @@ public class Comment {
         return c;
     }
 
-    public static Comment createByGuest(Post post, Comment parent, String nickname, String password, String content, String ipAddress) {
+    public static Comment createByPublic(Post post, Comment parent, String nickname, String password, String content, String ipAddress) {
         Comment c = new Comment(post, null, parent, nickname, password, content, ipAddress, false);
-        c.authorType = CommentAuthorType.GUEST;
+        c.authorType = CommentAuthorType.PUBLIC;
         return c;
     }
 

--- a/src/main/java/com/haem/blogbackend/global/common/enums/CommentAuthorType.java
+++ b/src/main/java/com/haem/blogbackend/global/common/enums/CommentAuthorType.java
@@ -2,5 +2,5 @@ package com.haem.blogbackend.global.common.enums;
 
 public enum CommentAuthorType {
     ADMIN,
-    GUEST
+    PUBLIC
 }

--- a/src/main/java/com/haem/blogbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/haem/blogbackend/global/config/SecurityConfig.java
@@ -44,11 +44,11 @@ public class SecurityConfig {
                     .requestMatchers("/api/admin/login").permitAll()
                     .requestMatchers("/uploadFiles/**").permitAll()
 
-                    // guest get 접근 허용
+                    // public get 접근 허용
                     .requestMatchers(HttpMethod.GET, "/api/categories/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/images/**").permitAll()
-                    .requestMatchers("/api/comments/**").permitAll() // guest 댓글 CRUD 위함
+                    .requestMatchers("/api/comments/**").permitAll() // public 댓글 CRUD 위함
                     .anyRequest().authenticated()
             )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## 개요
인증 여부와 관계없이 접근 가능한 댓글 작성자 영역의 도메인 의미를 명확히 하기 위해 `guest` 네이밍을 `public`으로 통일합니다.

## 주요 변경사항
- `CommentAuthorType` enum 값 `GUEST`를 `PUBLIC`으로 변경했습니다.
- `Comment.createByGuest` 팩토리 메서드를 `Comment.createByPublic`로 리네임하고 내부 authorType을 `PUBLIC`으로 변경했습니다.
- `CommentPublicService`의 댓글 생성 로직에서 `createByPublic`을 호출하도록 수정했습니다.
- `SecurityConfig` 주석 및 관련 표현의 `guest`를 `public`으로 정리했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b240b214ac83208620e44cbbc3c530)