### PR TITLE
feat: 카테고리별 포스트 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/haem/blogbackend/category/api/CategoryPublicController.java
+++ b/src/main/java/com/haem/blogbackend/category/api/CategoryPublicController.java
@@ -5,6 +5,9 @@ import com.haem.blogbackend.category.api.dto.CategoryResponseDto;
 import com.haem.blogbackend.category.application.CategoryPublicService;
 import com.haem.blogbackend.category.application.dto.CategoryPostCountResult;
 import com.haem.blogbackend.category.application.dto.CategorySummaryResult;
+import com.haem.blogbackend.post.api.dto.PostSummaryResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -46,5 +49,11 @@ public class CategoryPublicController {
         return results.stream()
                 .map(CategoryPostCountResponseDto::from)
                 .toList();
+    }
+
+    @GetMapping("/{categoryId}/posts")
+    public Page<PostSummaryResponseDto> getPostsByCategoryId(@PathVariable("categoryId") Long categoryId, Pageable pageable) {
+        return categoryPublicService.getPostsByCategoryId(categoryId, pageable)
+                .map(PostSummaryResponseDto::from);
     }
 }

--- a/src/main/java/com/haem/blogbackend/category/application/CategoryPublicService.java
+++ b/src/main/java/com/haem/blogbackend/category/application/CategoryPublicService.java
@@ -2,10 +2,16 @@ package com.haem.blogbackend.category.application;
 
 import com.haem.blogbackend.category.application.dto.CategoryPostCountResult;
 import com.haem.blogbackend.category.application.dto.CategorySummaryResult;
+import com.haem.blogbackend.category.domain.Category;
+import com.haem.blogbackend.category.domain.CategoryNotFoundException;
 import com.haem.blogbackend.category.domain.CategoryRepository;
+import com.haem.blogbackend.global.util.EntityFinder;
+import com.haem.blogbackend.post.application.dto.PostSummaryResult;
 import com.haem.blogbackend.post.domain.PostRepository;
 import com.haem.blogbackend.post.domain.PostNotFoundException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,10 +23,12 @@ import java.util.List;
 public class CategoryPublicService {
     private final CategoryRepository categoryRepository;
     private final PostRepository postRepository;
+    private final EntityFinder entityFinder;
 
-    public CategoryPublicService(CategoryRepository categoryRepository, PostRepository postRepository) {
+    public CategoryPublicService(CategoryRepository categoryRepository, PostRepository postRepository, EntityFinder entityFinder) {
         this.categoryRepository = categoryRepository;
         this.postRepository = postRepository;
+        this.entityFinder = entityFinder;
     }
 
     public List<CategorySummaryResult> getCategories() {
@@ -50,5 +58,19 @@ public class CategoryPublicService {
                 .stream()
                 .map(CategoryPostCountResult::from)
                 .toList();
+    }
+
+    public Page<PostSummaryResult> getPostsByCategoryId(Long categoryId, Pageable pageable) {
+        Category category = getCategoryOrThrow(categoryId);
+        return postRepository.findByCategoryIdAndDeletedAtIsNull(categoryId, pageable)
+                .map(post -> PostSummaryResult.from(post, category.getCategoryName()));
+    }
+
+    private Category getCategoryOrThrow(Long categoryId) {
+        return entityFinder.findByIdOrThrow(
+                categoryId,
+                categoryRepository,
+                () -> new CategoryNotFoundException(categoryId)
+        );
     }
 }


### PR DESCRIPTION
## 개요
카테고리 ID로 해당 카테고리의 포스트 목록을 페이징 조회하는 API 추가

## 주요 변경사항

### CategoryPublicController
- `GET /api/categories/{categoryId}/posts` 엔드포인트 추가
- Pageable 파라미터로 페이징 지원

### CategoryPublicService
- `getPostsByCategoryId()` 메서드 추가
- 카테고리 존재 여부 검증 후 포스트 조회
- `EntityFinder` 주입 추가

## 동작
- 존재하는 카테고리 ID로 요청 시 해당 카테고리 포스트 목록 반환 ✅
- 존재하지 않는 카테고리 ID로 요청 시 `CategoryNotFoundException` 발생 ✅
- 삭제된 포스트(`deletedAt IS NOT NULL`) 제외 ✅