### PR TITLE
feat: 이전/다음 글 조회 API 추가 (GET /api/posts/{id}/adjacent)

### DIFF
--- a/src/main/java/com/haem/blogbackend/post/api/PostPublicController.java
+++ b/src/main/java/com/haem/blogbackend/post/api/PostPublicController.java
@@ -1,5 +1,6 @@
 package com.haem.blogbackend.post.api;
 
+import com.haem.blogbackend.post.api.dto.PostAdjacentResponseDto;
 import com.haem.blogbackend.post.api.dto.PostResponseDto;
 import com.haem.blogbackend.post.api.dto.PostSummaryResponseDto;
 import com.haem.blogbackend.post.application.PostPublicService;
@@ -28,5 +29,10 @@ public class PostPublicController {
     @GetMapping("/{id}")
     public PostResponseDto getPost(@PathVariable("id") Long id) {
         return PostResponseDto.from(postPublicService.getPublicPost(id));
+    }
+
+    @GetMapping("/{id}/adjacent")
+    public PostAdjacentResponseDto getAdjacentPosts(@PathVariable("id") Long id) {
+        return PostAdjacentResponseDto.from(postPublicService.getAdjacentPosts(id));
     }
 }

--- a/src/main/java/com/haem/blogbackend/post/api/dto/AdjacentPostResponseDto.java
+++ b/src/main/java/com/haem/blogbackend/post/api/dto/AdjacentPostResponseDto.java
@@ -1,0 +1,27 @@
+package com.haem.blogbackend.post.api.dto;
+
+import com.haem.blogbackend.post.application.dto.AdjacentPostResult;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class AdjacentPostResponseDto {
+    private final Long id;
+    private final String title;
+    private final LocalDateTime createdAt;
+
+    private AdjacentPostResponseDto(Long id, String title, LocalDateTime createdAt) {
+        this.id = id;
+        this.title = title;
+        this.createdAt = createdAt;
+    }
+
+    public static AdjacentPostResponseDto from(AdjacentPostResult result) {
+        return new AdjacentPostResponseDto(
+                result.id(),
+                result.title(),
+                result.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/haem/blogbackend/post/api/dto/PostAdjacentResponseDto.java
+++ b/src/main/java/com/haem/blogbackend/post/api/dto/PostAdjacentResponseDto.java
@@ -1,0 +1,25 @@
+package com.haem.blogbackend.post.api.dto;
+
+import com.haem.blogbackend.post.application.dto.PostAdjacentResult;
+import lombok.Getter;
+
+@Getter
+public class PostAdjacentResponseDto {
+    private final AdjacentPostResponseDto prev;
+    private final AdjacentPostResponseDto next;
+
+    private PostAdjacentResponseDto(AdjacentPostResponseDto prev, AdjacentPostResponseDto next) {
+        this.prev = prev;
+        this.next = next;
+    }
+
+    public static PostAdjacentResponseDto from(PostAdjacentResult result) {
+        AdjacentPostResponseDto prev = result.prev() != null
+                ? AdjacentPostResponseDto.from(result.prev())
+                : null;
+        AdjacentPostResponseDto next = result.next() != null
+                ? AdjacentPostResponseDto.from(result.next())
+                : null;
+        return new PostAdjacentResponseDto(prev, next);
+    }
+}

--- a/src/main/java/com/haem/blogbackend/post/application/PostPublicService.java
+++ b/src/main/java/com/haem/blogbackend/post/application/PostPublicService.java
@@ -2,6 +2,8 @@ package com.haem.blogbackend.post.application;
 
 import com.haem.blogbackend.category.domain.Category;
 import com.haem.blogbackend.global.util.EntityFinder;
+import com.haem.blogbackend.post.application.dto.AdjacentPostResult;
+import com.haem.blogbackend.post.application.dto.PostAdjacentResult;
 import com.haem.blogbackend.post.application.dto.PostDetailResult;
 import com.haem.blogbackend.post.application.dto.PostSummaryResult;
 import com.haem.blogbackend.post.domain.Post;
@@ -39,5 +41,22 @@ public class PostPublicService {
         Post post = postRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new PostNotFoundException(id));
         return PostDetailResult.from(post);
+    }
+
+    public PostAdjacentResult getAdjacentPosts(Long id) {
+        Post post = postRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new PostNotFoundException(id));
+
+        AdjacentPostResult prev = postRepository
+                .findFirstByCreatedAtBeforeAndDeletedAtIsNullOrderByCreatedAtDesc(post.getCreatedAt())
+                .map(AdjacentPostResult::from)
+                .orElse(null);
+
+        AdjacentPostResult next = postRepository
+                .findFirstByCreatedAtAfterAndDeletedAtIsNullOrderByCreatedAtAsc(post.getCreatedAt())
+                .map(AdjacentPostResult::from)
+                .orElse(null);
+
+        return new PostAdjacentResult(prev, next);
     }
 }

--- a/src/main/java/com/haem/blogbackend/post/application/dto/AdjacentPostResult.java
+++ b/src/main/java/com/haem/blogbackend/post/application/dto/AdjacentPostResult.java
@@ -1,0 +1,19 @@
+package com.haem.blogbackend.post.application.dto;
+
+import com.haem.blogbackend.post.domain.Post;
+
+import java.time.LocalDateTime;
+
+public record AdjacentPostResult(
+        Long id,
+        String title,
+        LocalDateTime createdAt
+) {
+    public static AdjacentPostResult from(Post post) {
+        return new AdjacentPostResult(
+                post.getId(),
+                post.getTitle(),
+                post.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/haem/blogbackend/post/application/dto/PostAdjacentResult.java
+++ b/src/main/java/com/haem/blogbackend/post/application/dto/PostAdjacentResult.java
@@ -1,0 +1,6 @@
+package com.haem.blogbackend.post.application.dto;
+
+public record PostAdjacentResult(
+        AdjacentPostResult prev,
+        AdjacentPostResult next
+) {}

--- a/src/main/java/com/haem/blogbackend/post/domain/PostRepository.java
+++ b/src/main/java/com/haem/blogbackend/post/domain/PostRepository.java
@@ -4,12 +4,17 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     // public / 기본 조회(삭제 제외)
     Page<Post> findByDeletedAtIsNull(Pageable pageable);
     Optional<Post> findByIdAndDeletedAtIsNull(Long id);
+
+    // 이전/다음 글
+    Optional<Post> findFirstByCreatedAtBeforeAndDeletedAtIsNullOrderByCreatedAtDesc(LocalDateTime createdAt);
+    Optional<Post> findFirstByCreatedAtAfterAndDeletedAtIsNullOrderByCreatedAtAsc(LocalDateTime createdAt);
 
     long countByDeletedAtIsNull();
     Page<Post> findByCategoryIdAndDeletedAtIsNull(Long categoryId, Pageable pageable);


### PR DESCRIPTION
## 개요
게시글 상세 화면에서 이전/다음 글을 조회할 수 있는 API를 추가합니다.

## 주요 변경사항
- 게시글 기준 이전 글 조회 API 추가
- 게시글 기준 다음 글 조회 API 추가
- 삭제된 게시글(deletedAt IS NULL) 제외 처리
- Service 레이어에서 이전/다음 글 조회 로직 구현
- Response DTO 분리 (PostAdjacentResponseDto, AdjacentPostResponseDto)