### PR TITLE
feat: 게시글 제목/본문 검색 API 추가

### DIFF
--- a/src/main/java/com/haem/blogbackend/post/api/PostPublicController.java
+++ b/src/main/java/com/haem/blogbackend/post/api/PostPublicController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,8 +22,10 @@ public class PostPublicController {
     }
 
     @GetMapping
-    public Page<PostSummaryResponseDto> getPosts(Pageable pageable) {
-        return postPublicService.getPublicPosts(pageable)
+    public Page<PostSummaryResponseDto> getPosts(
+            @RequestParam(value = "keyword", required = false) String keyword,
+            Pageable pageable) {
+        return postPublicService.getPublicPosts(keyword, pageable)
                 .map(PostSummaryResponseDto::from);
     }
 

--- a/src/main/java/com/haem/blogbackend/post/application/PostPublicService.java
+++ b/src/main/java/com/haem/blogbackend/post/application/PostPublicService.java
@@ -27,14 +27,17 @@ public class PostPublicService {
         this.postRepository = postRepository;
     }
 
-    public Page<PostSummaryResult> getPublicPosts(Pageable pageable){
-        return postRepository.findByDeletedAtIsNull(pageable)
-                .map(post -> {
-                    String categoryName = Optional.ofNullable(post.getCategory())
-                            .map(Category::getCategoryName)
-                            .orElse("미분류");
-                    return PostSummaryResult.from(post, categoryName);
-                });
+    public Page<PostSummaryResult> getPublicPosts(String keyword, Pageable pageable){
+        Page<Post> posts = (keyword == null || keyword.isBlank())
+                ? postRepository.findByDeletedAtIsNull(pageable)
+                : postRepository.searchByKeyword(keyword.trim(), pageable);
+
+        return posts.map(post -> {
+            String categoryName = Optional.ofNullable(post.getCategory())
+                    .map(Category::getCategoryName)
+                    .orElse("미분류");
+            return PostSummaryResult.from(post, categoryName);
+        });
     }
 
     public PostDetailResult getPublicPost(Long id) {

--- a/src/main/java/com/haem/blogbackend/post/application/PostPublicService.java
+++ b/src/main/java/com/haem/blogbackend/post/application/PostPublicService.java
@@ -30,7 +30,7 @@ public class PostPublicService {
     public Page<PostSummaryResult> getPublicPosts(String keyword, Pageable pageable){
         Page<Post> posts = (keyword == null || keyword.isBlank())
                 ? postRepository.findByDeletedAtIsNull(pageable)
-                : postRepository.searchByKeyword(keyword.trim(), pageable);
+                : postRepository.searchByKeyword(escapeLikeKeyword(keyword.trim()), pageable);
 
         return posts.map(post -> {
             String categoryName = Optional.ofNullable(post.getCategory())
@@ -38,6 +38,14 @@ public class PostPublicService {
                     .orElse("미분류");
             return PostSummaryResult.from(post, categoryName);
         });
+    }
+
+    // LIKE 절의 와일드카드(%, _)를 리터럴로 취급하기 위한 이스케이프
+    private static String escapeLikeKeyword(String keyword) {
+        return keyword
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
     }
 
     public PostDetailResult getPublicPost(Long id) {

--- a/src/main/java/com/haem/blogbackend/post/domain/PostRepository.java
+++ b/src/main/java/com/haem/blogbackend/post/domain/PostRepository.java
@@ -14,10 +14,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByDeletedAtIsNull(Pageable pageable);
     Optional<Post> findByIdAndDeletedAtIsNull(Long id);
 
-    // 제목/본문 검색
+    // 제목/본문 검색 (keyword는 LIKE 와일드카드가 이스케이프된 상태로 전달되어야 함)
     @Query("SELECT p FROM Post p WHERE p.deletedAt IS NULL AND " +
-            "(LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
-            "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+            "(LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) ESCAPE '\\' " +
+            "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')) ESCAPE '\\')")
     Page<Post> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
     // 이전/다음 글

--- a/src/main/java/com/haem/blogbackend/post/domain/PostRepository.java
+++ b/src/main/java/com/haem/blogbackend/post/domain/PostRepository.java
@@ -3,6 +3,8 @@ package com.haem.blogbackend.post.domain;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -11,6 +13,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // public / 기본 조회(삭제 제외)
     Page<Post> findByDeletedAtIsNull(Pageable pageable);
     Optional<Post> findByIdAndDeletedAtIsNull(Long id);
+
+    // 제목/본문 검색
+    @Query("SELECT p FROM Post p WHERE p.deletedAt IS NULL AND " +
+            "(LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    Page<Post> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
     // 이전/다음 글
     Optional<Post> findFirstByCreatedAtBeforeAndDeletedAtIsNullOrderByCreatedAtDesc(LocalDateTime createdAt);


### PR DESCRIPTION
## 개요
- 게시글 목록 조회 API에 제목/본문 검색 기능을 추가했습니다.

## 주요 변경사항
- `GET /api/posts`에 `keyword` 쿼리 파라미터 추가
- `keyword`가 없는 경우 기존 전체 게시글 조회 로직 유지
- `keyword`가 있는 경우 제목 또는 본문을 대상으로 검색 수행
- 삭제되지 않은 게시글만 검색하도록 Repository 검색 쿼리 추가