### PR TITLE
fix: JWT 시크릿을 application-secret.properties로 분리

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,8 +16,8 @@ file.upload-dir=uploadFiles/
 spring.servlet.multipart.max-file-size=50MB
 spring.servlet.multipart.max-request-size=500MB
 
-# JWT 공통
-jwt.secret=dkanrjskdjWlehldjTrjsrlfrpTjqhausehlsmszldlqslek
+# JWT 공통 (jwt.secret 값은 application-secret.properties 에서 주입)
+jwt.secret=${JWT_SECRET}
 jwt.expiration=18000000
 
 # 로깅


### PR DESCRIPTION
## 개요
JWT 시크릿이 application.properties에 평문으로 포함되어 있던 문제를 수정했습니다. 시크릿 값을 코드에서 제거하고 application-secret.properties를 통해 환경별로 주입하도록 변경했습니다.

## 주요 변경사항
- application.properties의 하드코딩된 JWT 시크릿 제거
- jwt.secret을 `${JWT_SECRET}` 환경변수 참조 방식으로 변경
- application-secret.properties에서 JWT_SECRET을 관리하도록 변경
- 기존에 노출된 JWT 시크릿은 폐기되므로 배포 환경에도 새로운 JWT_SECRET 설정 필요