### PR TITLE
fix: 로그인 실패 응답을 통일하고 로그인 시도 횟수 제한 추가

### DIFF
--- a/src/main/java/com/haem/blogbackend/auth/api/AuthController.java
+++ b/src/main/java/com/haem/blogbackend/auth/api/AuthController.java
@@ -6,20 +6,24 @@ import com.haem.blogbackend.auth.domain.Admin;
 import com.haem.blogbackend.auth.api.dto.AdminLoginRequestDto;
 import com.haem.blogbackend.auth.api.dto.AdminLoginResponseDto;
 import com.haem.blogbackend.auth.api.dto.TokenVerifyResponseDto;
+import com.haem.blogbackend.global.util.ClientIpResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/admin")
 public class AuthController {
     private final AuthService authService;
+    private final ClientIpResolver clientIpResolver;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, ClientIpResolver clientIpResolver) {
         this.authService = authService;
+        this.clientIpResolver = clientIpResolver;
     }
 
     @PostMapping("/login")
-    public AdminLoginResponseDto adminLogin(@RequestBody AdminLoginRequestDto requestDto){
-        return authService.adminLogin(requestDto);
+    public AdminLoginResponseDto adminLogin(@RequestBody AdminLoginRequestDto requestDto, HttpServletRequest request){
+        return authService.adminLogin(requestDto, clientIpResolver.resolve(request));
     }
 
     @GetMapping("/check-token")

--- a/src/main/java/com/haem/blogbackend/auth/application/AuthService.java
+++ b/src/main/java/com/haem/blogbackend/auth/application/AuthService.java
@@ -4,6 +4,7 @@ import com.haem.blogbackend.auth.infrastructure.JwtProvider;
 import com.haem.blogbackend.auth.domain.AdminRepository;
 import com.haem.blogbackend.auth.domain.AdminNotFoundException;
 import com.haem.blogbackend.auth.domain.ExpiredTokenException;
+import com.haem.blogbackend.auth.domain.InvalidCredentialsException;
 import com.haem.blogbackend.auth.domain.Admin;
 import com.haem.blogbackend.auth.api.dto.AdminLoginRequestDto;
 import com.haem.blogbackend.auth.api.dto.AdminLoginResponseDto;
@@ -15,14 +16,17 @@ public class AuthService {
     private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final LoginRateLimitService loginRateLimitService;
 
-    public AuthService(AdminRepository adminRepository, PasswordEncoder passwordEncoder, JwtProvider jwtProvider) {
+    public AuthService(AdminRepository adminRepository, PasswordEncoder passwordEncoder, JwtProvider jwtProvider, LoginRateLimitService loginRateLimitService) {
         this.adminRepository = adminRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtProvider = jwtProvider;
+        this.loginRateLimitService = loginRateLimitService;
     }
 
-    public AdminLoginResponseDto adminLogin(AdminLoginRequestDto requestDto){
+    public AdminLoginResponseDto adminLogin(AdminLoginRequestDto requestDto, String ipAddress){
+        loginRateLimitService.validate(ipAddress);
         Admin admin = getVerifiedAdmin(requestDto);
         String token = jwtProvider.generateToken(admin);
 
@@ -35,9 +39,10 @@ public class AuthService {
     }
 
     private Admin getVerifiedAdmin(AdminLoginRequestDto requestDto){
-        Admin admin = getAdminOrThrow(requestDto.getAccountName());
+        Admin admin = adminRepository.findByAccountName(requestDto.getAccountName())
+                .orElseThrow(InvalidCredentialsException::new);
         if(!passwordEncoder.matches(requestDto.getPassword(), admin.getPassword())){
-            throw new IllegalArgumentException("아이디 혹은 비밀번호가 일치하지 않습니다.");
+            throw new InvalidCredentialsException();
         }
         return admin;
     }

--- a/src/main/java/com/haem/blogbackend/auth/application/AuthService.java
+++ b/src/main/java/com/haem/blogbackend/auth/application/AuthService.java
@@ -26,10 +26,17 @@ public class AuthService {
     }
 
     public AdminLoginResponseDto adminLogin(AdminLoginRequestDto requestDto, String ipAddress){
-        loginRateLimitService.validate(ipAddress);
-        Admin admin = getVerifiedAdmin(requestDto);
-        String token = jwtProvider.generateToken(admin);
+        loginRateLimitService.checkAllowed(ipAddress);
 
+        Admin admin;
+        try {
+            admin = getVerifiedAdmin(requestDto);
+        } catch (InvalidCredentialsException e) {
+            loginRateLimitService.recordFailure(ipAddress);
+            throw e;
+        }
+
+        String token = jwtProvider.generateToken(admin);
         return AdminLoginResponseDto.from(admin, token);
     }
 

--- a/src/main/java/com/haem/blogbackend/auth/application/LoginRateLimitService.java
+++ b/src/main/java/com/haem/blogbackend/auth/application/LoginRateLimitService.java
@@ -20,24 +20,33 @@ public class LoginRateLimitService {
     public void checkAllowed(String ipAddress) {
         LocalDateTime threshold = LocalDateTime.now().minusSeconds(WINDOW_SECONDS);
 
-        Deque<LocalDateTime> requestTimes = requestHistoryByIp.computeIfAbsent(ipAddress, key -> new ArrayDeque<>());
+        requestHistoryByIp.compute(ipAddress, (key, requestTimes) -> {
+            Deque<LocalDateTime> times = requestTimes != null ? requestTimes : new ArrayDeque<>();
+            prune(times, threshold);
 
-        synchronized (requestTimes) {
-            while (!requestTimes.isEmpty() && requestTimes.peekFirst().isBefore(threshold)) {
-                requestTimes.pollFirst();
-            }
-
-            if (requestTimes.size() >= MAX_REQUEST_COUNT) {
+            if (times.size() >= MAX_REQUEST_COUNT) {
                 throw new LoginRateLimitExceededException();
             }
-        }
+
+            // 빈 기록은 Map에 남기지 않는다
+            return times.isEmpty() ? null : times;
+        });
     }
 
     public void recordFailure(String ipAddress) {
-        Deque<LocalDateTime> requestTimes = requestHistoryByIp.computeIfAbsent(ipAddress, key -> new ArrayDeque<>());
+        LocalDateTime threshold = LocalDateTime.now().minusSeconds(WINDOW_SECONDS);
 
-        synchronized (requestTimes) {
-            requestTimes.addLast(LocalDateTime.now());
+        requestHistoryByIp.compute(ipAddress, (key, requestTimes) -> {
+            Deque<LocalDateTime> times = requestTimes != null ? requestTimes : new ArrayDeque<>();
+            prune(times, threshold);
+            times.addLast(LocalDateTime.now());
+            return times;
+        });
+    }
+
+    private void prune(Deque<LocalDateTime> requestTimes, LocalDateTime threshold) {
+        while (!requestTimes.isEmpty() && requestTimes.peekFirst().isBefore(threshold)) {
+            requestTimes.pollFirst();
         }
     }
 }

--- a/src/main/java/com/haem/blogbackend/auth/application/LoginRateLimitService.java
+++ b/src/main/java/com/haem/blogbackend/auth/application/LoginRateLimitService.java
@@ -1,0 +1,38 @@
+package com.haem.blogbackend.auth.application;
+
+import com.haem.blogbackend.auth.domain.LoginRateLimitExceededException;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class LoginRateLimitService {
+
+    private static final int MAX_REQUEST_COUNT = 5;
+    private static final long WINDOW_SECONDS = 300;
+
+    private final Map<String, Deque<LocalDateTime>> requestHistoryByIp = new ConcurrentHashMap<>();
+
+    public void validate(String ipAddress) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime threshold = now.minusSeconds(WINDOW_SECONDS);
+
+        Deque<LocalDateTime> requestTimes = requestHistoryByIp.computeIfAbsent(ipAddress, key -> new ArrayDeque<>());
+
+        synchronized (requestTimes) {
+            while (!requestTimes.isEmpty() && requestTimes.peekFirst().isBefore(threshold)) {
+                requestTimes.pollFirst();
+            }
+
+            if (requestTimes.size() >= MAX_REQUEST_COUNT) {
+                throw new LoginRateLimitExceededException();
+            }
+
+            requestTimes.addLast(now);
+        }
+    }
+}

--- a/src/main/java/com/haem/blogbackend/auth/application/LoginRateLimitService.java
+++ b/src/main/java/com/haem/blogbackend/auth/application/LoginRateLimitService.java
@@ -17,9 +17,8 @@ public class LoginRateLimitService {
 
     private final Map<String, Deque<LocalDateTime>> requestHistoryByIp = new ConcurrentHashMap<>();
 
-    public void validate(String ipAddress) {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime threshold = now.minusSeconds(WINDOW_SECONDS);
+    public void checkAllowed(String ipAddress) {
+        LocalDateTime threshold = LocalDateTime.now().minusSeconds(WINDOW_SECONDS);
 
         Deque<LocalDateTime> requestTimes = requestHistoryByIp.computeIfAbsent(ipAddress, key -> new ArrayDeque<>());
 
@@ -31,8 +30,14 @@ public class LoginRateLimitService {
             if (requestTimes.size() >= MAX_REQUEST_COUNT) {
                 throw new LoginRateLimitExceededException();
             }
+        }
+    }
 
-            requestTimes.addLast(now);
+    public void recordFailure(String ipAddress) {
+        Deque<LocalDateTime> requestTimes = requestHistoryByIp.computeIfAbsent(ipAddress, key -> new ArrayDeque<>());
+
+        synchronized (requestTimes) {
+            requestTimes.addLast(LocalDateTime.now());
         }
     }
 }

--- a/src/main/java/com/haem/blogbackend/auth/domain/InvalidCredentialsException.java
+++ b/src/main/java/com/haem/blogbackend/auth/domain/InvalidCredentialsException.java
@@ -1,8 +1,8 @@
 package com.haem.blogbackend.auth.domain;
 
-import com.haem.blogbackend.global.error.exception.base.TokenException;
+import com.haem.blogbackend.global.error.exception.base.UnauthorizedException;
 
-public class InvalidCredentialsException extends TokenException {
+public class InvalidCredentialsException extends UnauthorizedException {
     public InvalidCredentialsException() {
         super("아이디 또는 비밀번호가 올바르지 않습니다.");
     }

--- a/src/main/java/com/haem/blogbackend/auth/domain/InvalidCredentialsException.java
+++ b/src/main/java/com/haem/blogbackend/auth/domain/InvalidCredentialsException.java
@@ -1,0 +1,9 @@
+package com.haem.blogbackend.auth.domain;
+
+import com.haem.blogbackend.global.error.exception.base.TokenException;
+
+public class InvalidCredentialsException extends TokenException {
+    public InvalidCredentialsException() {
+        super("아이디 또는 비밀번호가 올바르지 않습니다.");
+    }
+}

--- a/src/main/java/com/haem/blogbackend/auth/domain/LoginRateLimitExceededException.java
+++ b/src/main/java/com/haem/blogbackend/auth/domain/LoginRateLimitExceededException.java
@@ -1,8 +1,8 @@
 package com.haem.blogbackend.auth.domain;
 
-import com.haem.blogbackend.global.error.exception.base.BadRequestException;
+import com.haem.blogbackend.global.error.exception.base.TooManyRequestsException;
 
-public class LoginRateLimitExceededException extends BadRequestException {
+public class LoginRateLimitExceededException extends TooManyRequestsException {
     public LoginRateLimitExceededException() {
         super("로그인 시도가 너무 많습니다. 잠시 후 다시 시도해주세요.");
     }

--- a/src/main/java/com/haem/blogbackend/auth/domain/LoginRateLimitExceededException.java
+++ b/src/main/java/com/haem/blogbackend/auth/domain/LoginRateLimitExceededException.java
@@ -1,0 +1,9 @@
+package com.haem.blogbackend.auth.domain;
+
+import com.haem.blogbackend.global.error.exception.base.BadRequestException;
+
+public class LoginRateLimitExceededException extends BadRequestException {
+    public LoginRateLimitExceededException() {
+        super("로그인 시도가 너무 많습니다. 잠시 후 다시 시도해주세요.");
+    }
+}

--- a/src/main/java/com/haem/blogbackend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/haem/blogbackend/global/error/GlobalExceptionHandler.java
@@ -2,8 +2,8 @@ package com.haem.blogbackend.global.error;
 
 import com.haem.blogbackend.global.error.exception.base.BadRequestException;
 import com.haem.blogbackend.global.error.exception.base.InvalidFileException;
-import com.haem.blogbackend.global.error.exception.base.TokenException;
 import com.haem.blogbackend.global.error.exception.base.TooManyRequestsException;
+import com.haem.blogbackend.global.error.exception.base.UnauthorizedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -31,9 +31,9 @@ public class GlobalExceptionHandler {
     }
 
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(TokenException.class)
-    public ErrorResponse handleTokenException(TokenException e) {
-        log.warn("TokenException 발생 {}", e.getMessage());
+    @ExceptionHandler(UnauthorizedException.class)
+    public ErrorResponse handleUnauthorized(UnauthorizedException e) {
+        log.warn("인증 실패 {}", e.getMessage());
         return ErrorResponse.of(e.getMessage(), HttpStatus.UNAUTHORIZED);
     }
 

--- a/src/main/java/com/haem/blogbackend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/haem/blogbackend/global/error/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.haem.blogbackend.global.error;
 import com.haem.blogbackend.global.error.exception.base.BadRequestException;
 import com.haem.blogbackend.global.error.exception.base.InvalidFileException;
 import com.haem.blogbackend.global.error.exception.base.TokenException;
+import com.haem.blogbackend.global.error.exception.base.TooManyRequestsException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,6 +35,12 @@ public class GlobalExceptionHandler {
     public ErrorResponse handleTokenException(TokenException e) {
         log.warn("TokenException 발생 {}", e.getMessage());
         return ErrorResponse.of(e.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+
+    @ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
+    @ExceptionHandler(TooManyRequestsException.class)
+    public ErrorResponse handleTooManyRequests(TooManyRequestsException e) {
+        return ErrorResponse.of(e.getMessage(), HttpStatus.TOO_MANY_REQUESTS);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/haem/blogbackend/global/error/exception/base/TokenException.java
+++ b/src/main/java/com/haem/blogbackend/global/error/exception/base/TokenException.java
@@ -1,6 +1,6 @@
 package com.haem.blogbackend.global.error.exception.base;
 
-public abstract class TokenException extends RuntimeException {
+public abstract class TokenException extends UnauthorizedException {
     public TokenException(String message) {
         super(message);
     }

--- a/src/main/java/com/haem/blogbackend/global/error/exception/base/TooManyRequestsException.java
+++ b/src/main/java/com/haem/blogbackend/global/error/exception/base/TooManyRequestsException.java
@@ -1,0 +1,7 @@
+package com.haem.blogbackend.global.error.exception.base;
+
+public abstract class TooManyRequestsException extends RuntimeException {
+    public TooManyRequestsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/haem/blogbackend/global/error/exception/base/UnauthorizedException.java
+++ b/src/main/java/com/haem/blogbackend/global/error/exception/base/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.haem.blogbackend.global.error.exception.base;
+
+public abstract class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## 개요
로그인 과정에서 계정 존재 여부가 노출될 수 있는 문제를 수정하고, 무차별 대입 공격을 방지하기 위해 IP 기준 로그인 시도 횟수 제한을 추가했습니다.

## 주요 변경사항
- 로그인 실패 시 계정 미존재와 비밀번호 불일치 응답을 동일한 예외로 통일
- `InvalidCredentialsException`을 추가하여 로그인 실패 시 동일한 메시지와 상태 코드 반환
- `ClientIpResolver`를 이용해 클라이언트 IP를 조회하도록 변경
- `LoginRateLimitService`를 추가하여 IP당 5분간 최대 5회 로그인 시도로 제한
- 로그인 API에서 Rate Limit 검증 로직 적용