### PR TITLE
fix: ClientIpResolver가 리버스 프록시 뒤에서 실제 클라이언트 IP를 못 읽던 문제 수정

### DIFF
--- a/src/main/java/com/haem/blogbackend/global/util/ClientIpResolver.java
+++ b/src/main/java/com/haem/blogbackend/global/util/ClientIpResolver.java
@@ -7,6 +7,18 @@ import org.springframework.stereotype.Component;
 public class ClientIpResolver {
 
     public String resolve(HttpServletRequest request) {
+        // 프록시/로드밸런서 환경 고려: X-Forwarded-For 우선
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank()) {
+            // XFF는 "client, proxy1, proxy2" 형태일 수 있음 → 첫 번째가 원 IP인 경우가 일반적
+            return xff.split(",")[0].trim();
+        }
+
+        String realIp = request.getHeader("X-Real-IP");
+        if (realIp != null && !realIp.isBlank()) {
+            return realIp.trim();
+        }
+
         return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/haem/blogbackend/visit/infrastructure/VisitTrackingFilter.java
+++ b/src/main/java/com/haem/blogbackend/visit/infrastructure/VisitTrackingFilter.java
@@ -1,5 +1,6 @@
 package com.haem.blogbackend.visit.infrastructure;
 
+import com.haem.blogbackend.global.util.ClientIpResolver;
 import com.haem.blogbackend.visit.application.VisitService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -14,9 +15,11 @@ import java.time.LocalDate;
 @Component
 public class VisitTrackingFilter extends OncePerRequestFilter {
     private final VisitService visitService;
+    private final ClientIpResolver clientIpResolver;
 
-    public VisitTrackingFilter(VisitService visitService) {
+    public VisitTrackingFilter(VisitService visitService, ClientIpResolver clientIpResolver) {
         this.visitService = visitService;
+        this.clientIpResolver = clientIpResolver;
     }
 
     @Override
@@ -55,7 +58,7 @@ public class VisitTrackingFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
 
         try {
-            String clientIp = resolveClientIp(request);
+            String clientIp = clientIpResolver.resolve(request);
             String userAgent = request.getHeader("User-Agent");
 
             // 개인정보 보호: ip 자체를 저장하지 않고, 서비스에서 해시 처리/저장한다고 가정
@@ -68,22 +71,6 @@ public class VisitTrackingFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
-    }
-
-    private String resolveClientIp(HttpServletRequest request) {
-        // 프록시/로드밸런서 환경 고려: X-Forwarded-For 우선
-        String xff = request.getHeader("X-Forwarded-For");
-        if (xff != null && !xff.isBlank()) {
-            // XFF는 "client, proxy1, proxy2" 형태일 수 있음 → 첫 번째가 원 IP인 경우가 일반적
-            return xff.split(",")[0].trim();
-        }
-
-        String realIp = request.getHeader("X-Real-IP");
-        if (realIp != null && !realIp.isBlank()) {
-            return realIp.trim();
-        }
-
-        return request.getRemoteAddr();
     }
 
 }


### PR DESCRIPTION
## 개요
리버스 프록시 환경에서 `request.getRemoteAddr()`이 실제 사용자 IP가 아닌 프록시 IP를 반환하는 문제를 수정했습니다.

이로 인해 로그인 및 댓글 Rate Limit이 개별 클라이언트 기준이 아닌 프록시 IP 기준으로 동작할 수 있던 문제를 개선했습니다.

## 주요 변경사항
- `ClientIpResolver`에 `X-Forwarded-For`, `X-Real-IP` 기반 IP 조회 로직 추가
- `VisitTrackingFilter`의 중복 IP 조회 로직 제거
- 공통 `ClientIpResolver`를 사용하도록 변경
- 로그인/댓글 Rate Limit이 실제 클라이언트 IP 기준으로 동작하도록 개선